### PR TITLE
Face Shape Inversion, Eye Look improvement, Module Behavior and Connection printout improvement

### DIFF
--- a/VRC_iFacialMocap/VRC_iFacialMocap.csproj
+++ b/VRC_iFacialMocap/VRC_iFacialMocap.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
 	  <TargetFramework>net7.0</TargetFramework>
@@ -28,12 +28,11 @@
 	<ItemGroup>
 		<Folder Include="Properties\" />
 	</ItemGroup>
-	
-	
-  <ItemGroup>
-    <Reference Include="VRCFaceTracking.Core">
-        <HintPath>../VRCFaceTracking.Core.dll</HintPath>
-    </Reference>
-</ItemGroup>
+
+	<ItemGroup>
+	  <Reference Include="VRCFaceTracking.Core">
+	    <HintPath>..\..\cores\5.1.1.0\VRCFaceTracking.Core.dll</HintPath>
+	  </Reference>
+	</ItemGroup>
 
 </Project>

--- a/VRC_iFacialMocap/src/iFacialMocapServer.cs
+++ b/VRC_iFacialMocap/src/iFacialMocapServer.cs
@@ -86,7 +86,7 @@ namespace iFacialMocapTrackingModule
 
 
         /// <summary>
-        /// Reads and parses the data recieved by the UDP Client, 
+        /// Reads and parses the data received by the UDP Client, 
         /// storing the facial data result in the Face Data attributes.
         /// </summary>
 
@@ -102,7 +102,7 @@ namespace iFacialMocapTrackingModule
                     if (isTracking==false)
                     {
                         isTracking = true;
-                        logger.LogInformation("Tracking restablished");
+                        logger.LogInformation("Tracking reestablished");
                     }
                     string[] blendData = returnData.Split('|')[1..^1];
                     int i = 0;
@@ -125,7 +125,7 @@ namespace iFacialMocapTrackingModule
                 }
 
                 /// <summary>
-                /// Changes the facial data depending of the assignation recieved.
+                /// Changes the facial data depending of the assignation received.
                 /// </summary>
                 /// <param name="blend"></param>
                 void HandleChange(string blend, ref ILogger logger)
@@ -147,21 +147,21 @@ namespace iFacialMocapTrackingModule
                             if (values.Length == 6)
                                 _trackedData.head = values;
                             else
-                                logger.LogWarning("Insuficient data to assign head's position");
+                                logger.LogWarning("Insufficient data to assign head's position");
                         }
                         else if (assignVal[0] == "rightEye")
                         {
                             if (values.Length == 3)
                                 _trackedData.rightEye = values;
                             else
-                                logger.LogWarning("Insuficient data to assign right eye's position");
+                                logger.LogWarning("Insufficient data to assign right eye's position");
                         }
                         else if (assignVal[0] == "leftEye")
                         {
                             if (values.Length == 3)
                                 _trackedData.leftEye = values;
                             else
-                                logger.LogWarning("Insuficient data to assign left eye's position");
+                                logger.LogWarning("Insufficient data to assign left eye's position");
                         }
                         else
                         {

--- a/VRC_iFacialMocap/src/iFacialMocapServer.cs
+++ b/VRC_iFacialMocap/src/iFacialMocapServer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Globalization;
 using System.Net;
 using System.Net.Sockets;
@@ -12,14 +13,28 @@ namespace iFacialMocapTrackingModule
         static private int _port = 49983; //port
         private FacialMocapData _trackedData = new();
         private UdpClient? _udpListener, _udpClient;
-        private IPEndPoint? _dstAddr;
+        private IPEndPoint? _remoteIpEndPoint;
         public bool isTracking;
+        private ILogger _logger;
+
+        private Thread? _receiveThread;
+        private CancellationTokenSource _cts;
+
+        // call it a disconnect if we stop receiving after 5 seconds
+        private int _receiveTimeoutMs = 5000;
+
         public FacialMocapData FaceData { get { return _trackedData; } }
+
+        public iFacialMocapServer(ref ILogger logger) { 
+            _logger = logger; 
+            _cts = new CancellationTokenSource();
+        }
 
         /// <summary>
         /// Stops and disposes the clients
         public void Stop()
         {
+            _cts.Cancel();
             if (_udpClient != null) { _udpClient.Close(); _udpClient.Dispose(); }
             if (_udpListener != null) { _udpListener.Close(); _udpListener.Dispose(); }
             FaceData.blends.Clear();
@@ -41,13 +56,13 @@ namespace iFacialMocapTrackingModule
         /// Connects to the Facial Mockup server socket.
         /// </summary>
         /// <param name="ipaddress"></param>
-        public bool Connect(ref ILogger logger, string ipaddress = "255.255.255.255")
+        public bool Connect(string ipaddress = "255.255.255.255")
         {
             isTracking = false;
 
             _udpListener = new(_port);
             _udpClient = new();
-            _dstAddr = new IPEndPoint(IPAddress.Any, _port);
+            _remoteIpEndPoint = new IPEndPoint(IPAddress.Any, _port);
 
             var timeToWait = TimeSpan.FromSeconds(120);
             // compile list of IP addresses
@@ -77,7 +92,7 @@ namespace iFacialMocapTrackingModule
                         }
                         catch (FormatException)
                         {
-                            logger.LogError("Invalid IP address happened somehow..");
+                            _logger.LogError("Invalid IP address happened somehow..");
                             continue;
                         }
                         // 172.16.0.0 to 172.31.255.255, providing about 1 million unique IP addresses 
@@ -94,12 +109,12 @@ namespace iFacialMocapTrackingModule
             }
             if (likelyIpAddressList.Length == 0 && otherIpAddressList.Length == 0)
             {
-                logger.LogError("No local network connection found!");
+                _logger.LogError("No local network connection found!");
                 return false;
             }
-            logger.LogInformation($"Seeking iFacialMocap connection for {timeToWait.TotalSeconds} seconds. " +
+            _logger.LogInformation($"Seeking iFacialMocap connection for {timeToWait.TotalSeconds} seconds. " +
                 $"Accepting data on: \n\nIP Address(es)\n========================{likelyIpAddressList}\n========================\n\nUse default iFacialMocap Port: {_port}\n");
-            logger.LogDebug($"Other IP Addresses found: \n{otherIpAddressList}\n");
+            _logger.LogDebug($"Other IP Addresses found: \n{otherIpAddressList}\n");
 
             var asyncResult = _udpListener.BeginReceive(null, null);
 
@@ -109,155 +124,181 @@ namespace iFacialMocapTrackingModule
                 try
                 {
                     // EndReceive worked and we have received data and remote endpoint
-                    byte[] receivedBytes = _udpListener.EndReceive(asyncResult, ref _dstAddr);
-                    logger.LogInformation("Successful message receive");
+                    byte[] receivedBytes = _udpListener.EndReceive(asyncResult, ref _remoteIpEndPoint);
+                    _logger.LogInformation("Successful message receive");
 
                     //IPEndPoint dstAddr = new(IPAddress.Parse(ipaddress), _port);
                     string data = "iFacialMocap_sahuasouryya9218sauhuiayeta91555dy3719|sendDataVersion=v2";
                     byte[] bytes = Encoding.UTF8.GetBytes(data);
-                    _udpClient.Send(bytes, bytes.Length, _dstAddr);
+                    _udpClient.Send(bytes, bytes.Length, _remoteIpEndPoint);
+                    // for synchronous receives, which ReceiveAsync won't use...
                     _udpListener.Client.ReceiveTimeout = 1000;
-                    if (_dstAddr == null)
+                    if (_remoteIpEndPoint == null)
                     {
-                        logger.LogWarning("Something went really wrong! Could not identify remote endpoint");
+                        _logger.LogWarning("Something went really wrong! Could not identify remote endpoint");
                         return false;
                     }
-                    logger.LogInformation($"Connecting to {_dstAddr.Address}:{_dstAddr.Port}");
+                    _logger.LogInformation($"Connecting to {_remoteIpEndPoint.Address}:{_remoteIpEndPoint.Port}");
                     isTracking = true;
+
+                    // start async thread for receive
+                    //_receiveThread = new Thread(async () => await ReadDataThread());
+                    //_receiveThread.Start();
+                    Task.Run(() => ReadDataThread());
+
                     return isTracking;
                 }
                 catch (Exception ex)
                 {
                     // EndReceive failed and we ended up here
-                    logger.LogError($"Error Occurred Attempting Receiving Data: {ex.ToString()}");
+                    _logger.LogError($"Error Occurred Attempting Receiving Data: {ex.ToString()}");
                 }
             }
             else
             {
                 // The operation wasn't completed before the timeout and we're off the hook
                 // nothing init so return false
-                logger.LogWarning("Did not receive iFacialMocap message within initialization period, re-initialize the module to try again...");
+                _logger.LogWarning("Did not receive iFacialMocap message within initialization period, re-initialize the module to try again...");
                 return false;
             }
 
             return false;
         }
 
+        private async Task ReadDataThread()
+        {
+            _logger.LogDebug("Starting iFacialMocap Receive thread");
+
+            while (!_cts.IsCancellationRequested)
+            {
+                await ReadData();
+            }
+            _logger.LogDebug("iFacialMocap receive thread ended");
+        }
 
         /// <summary>
         /// Reads and parses the data received by the UDP Client, 
         /// storing the facial data result in the Face Data attributes.
         /// </summary>
 
-        public void ReadData(ref ILogger logger)
+        public async Task ReadData()
         {
            if (_udpListener != null)
-            {
-
-                  IPEndPoint? RemoteIpEndPoint = null;
+           {
+                //IPEndPoint? RemoteIpEndPoint = null;
                 try {
-                  byte[] receiveBytes = _udpListener.Receive(ref RemoteIpEndPoint);
-                    string returnData = Encoding.ASCII.GetString(receiveBytes);
-                    if (isTracking==false)
+                    CancellationTokenSource receiveTimeOutCTS = new();
+                    receiveTimeOutCTS.CancelAfter(_receiveTimeoutMs);
+                    CancellationTokenSource linkedCTS = CancellationTokenSource.CreateLinkedTokenSource(receiveTimeOutCTS.Token, _cts.Token);
+                    var receiveTask = _udpListener.ReceiveAsync(linkedCTS.Token);
+                    await receiveTask;
+                    if (!receiveTask.IsCompleted)
+                    {
+                        throw new TimeoutException();
+                    }
+                    string returnData = Encoding.ASCII.GetString(receiveTask.Result.Buffer);
+                    if (isTracking == false)
                     {
                         isTracking = true;
-                        logger.LogInformation("Tracking reestablished");
+                        _logger.LogInformation("iFacialMocap message received. Datastream re-established..");
                     }
                     string[] blendData = returnData.Split('|')[1..^1];
                     int i = 0;
                     while (i < blendData.Length) //While in the int attributes
                     {
-                        HandleChange(blendData[i], ref logger);
+                        HandleChange(blendData[i]);
                         i++;
                     }
                 }
                 catch(Exception e)
                 {
-                    logger.LogError("Module has disconnected, waiting for reconnection...");
+                    if (isTracking)
+                    {
+                        _logger.LogError("Module failed to receive message from iFacialMocap after 5 seconds, waiting for reconnection...");
+                    }
                     isTracking = false;
                 }
 
-                }
-                else
-                {
-                    logger.LogError("UDPClient wasn't initialized.");
-                }
+           }
+           else
+           {
+               _logger.LogError("UDPClient wasn't initialized.");
+           }
+        }
 
-                /// <summary>
-                /// Changes the facial data depending of the assignation received.
-                /// </summary>
-                /// <param name="blend"></param>
-                void HandleChange(string blend, ref ILogger logger)
+        /// <summary>
+        /// Changes the facial data depending of the assignation received.
+        /// </summary>
+        /// <param name="blend"></param>
+        private void HandleChange(string blend)
+        {
+            if (blend.Contains('#'))
+            {
+                string[] assignVal = blend.Split('#');
+                try
                 {
-                if (blend.Contains('#'))
-                {
-                    string[] assignVal = blend.Split('#');
-                    try
+                    string[] unparsedValues = assignVal[1].Split(',');
+                    float[] values = new float[unparsedValues.Length];
+
+                    for (int j = 0; j < unparsedValues.Length; j++)
                     {
-                        string[] unparsedValues = assignVal[1].Split(',');
-                        float[] values = new float[unparsedValues.Length];
-
-                        for (int j = 0; j < unparsedValues.Length; j++)
-                        {
-                            values[j] = float.Parse(unparsedValues[j], CultureInfo.InvariantCulture.NumberFormat);
-                        }
-                        if (assignVal[0] == "=head")
-                        {
-                            if (values.Length == 6)
-                                _trackedData.head = values;
-                            else
-                                logger.LogWarning("Insufficient data to assign head's position");
-                        }
-                        else if (assignVal[0] == "rightEye")
-                        {
-                            if (values.Length == 3)
-                                _trackedData.rightEye = values;
-                            else
-                                logger.LogWarning("Insufficient data to assign right eye's position");
-                        }
-                        else if (assignVal[0] == "leftEye")
-                        {
-                            if (values.Length == 3)
-                                _trackedData.leftEye = values;
-                            else
-                                logger.LogWarning("Insufficient data to assign left eye's position");
-                        }
+                        values[j] = float.Parse(unparsedValues[j], CultureInfo.InvariantCulture.NumberFormat);
+                    }
+                    if (assignVal[0] == "=head")
+                    {
+                        if (values.Length == 6)
+                            _trackedData.head = values;
                         else
-                        {
-                            logger.LogWarning($"Error on setting {assignVal}.");
-                            return;
-                        }
+                            _logger.LogWarning("Insufficient data to assign head's position");
                     }
-                    catch (Exception e)
+                    else if (assignVal[0] == "rightEye")
                     {
-                        logger.LogWarning($"Invalid assignation. [{e};;{blend}]");
-                        return;
+                        if (values.Length == 3)
+                            _trackedData.rightEye = values;
+                        else
+                            _logger.LogWarning("Insufficient data to assign right eye's position");
                     }
-
-                }
-                else if (blend.Contains('-') || blend.Contains('&'))
+                    else if (assignVal[0] == "leftEye")
                     {
-                    char separator = blend.Contains('&') ? '&' : '-';
-                        string[] assignVal = blend.Split(separator);
-                        try
-                        {
-                            _trackedData.blends[assignVal[0]] = int.Parse(assignVal[1]);
-
-                        }
-                        catch (Exception e)
-                        {
-                            logger.LogWarning($"Invalid assignation. [{e};;{blend}]");
-                            return;
-                        }
+                        if (values.Length == 3)
+                            _trackedData.leftEye = values;
+                        else
+                            _logger.LogWarning("Insufficient data to assign left eye's position");
                     }
-                    
                     else
                     {
-                        logger.LogWarning($"Data cropped.");
+                        _logger.LogWarning($"Error on setting {assignVal}.");
+                        return;
                     }
+                }
+                catch (Exception e)
+                {
+                    _logger.LogWarning($"Invalid assignation. [{e};;{blend}]");
+                    return;
+                }
+
+            }
+            else if (blend.Contains('-') || blend.Contains('&'))
+            {
+                char separator = blend.Contains('&') ? '&' : '-';
+                string[] assignVal = blend.Split(separator);
+                try
+                {
+                    _trackedData.blends[assignVal[0]] = int.Parse(assignVal[1]);
 
                 }
-            
+                catch (Exception e)
+                {
+                    _logger.LogWarning($"Invalid assignation. [{e};;{blend}]");
+                    return;
+                }
+            }
+
+            else
+            {
+                _logger.LogWarning($"Data cropped.");
+            }
         }
+
     }
 }

--- a/VRC_iFacialMocap/src/iFacialMocapTrackingInterface.cs
+++ b/VRC_iFacialMocap/src/iFacialMocapTrackingInterface.cs
@@ -46,7 +46,7 @@ public class iFacialMocapTrackingInterface : ExtTrackingModule
                 UpdateData();
             }
             // Add a delay or halt for the next update cycle for performance. eg: 
-            Thread.Sleep(1);
+            Thread.Sleep(10);
         }
     }
 
@@ -81,11 +81,14 @@ public class iFacialMocapTrackingInterface : ExtTrackingModule
                 server.FaceData.BlendValue("eyeBlink_R") * server.FaceData.BlendValue("eyeSquint_R")));
 
         #endregion
+
+        //// ===== iFacialMocap output by default (from ARKit) mirrors R/L because it's normal use-case is in a application acting as a mirror!!! ===== ////
+
         #region Eye Blends
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.EyeSquintLeft].Weight = server.FaceData.BlendValue("eyeSquint_L");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.EyeSquintRight].Weight = server.FaceData.BlendValue("eyeSquint_R");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.EyeWideLeft].Weight = server.FaceData.BlendValue("eyeWide_L");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.EyeWideRight].Weight = server.FaceData.BlendValue("eyeWide_R");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.EyeSquintLeft].Weight = server.FaceData.BlendValue("eyeSquint_R");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.EyeSquintRight].Weight = server.FaceData.BlendValue("eyeSquint_L");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.EyeWideLeft].Weight = server.FaceData.BlendValue("eyeWide_R");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.EyeWideRight].Weight = server.FaceData.BlendValue("eyeWide_L");
         #endregion
         #region Pupil
         //EyeDilation & EyeConstrict default in mid value idk
@@ -95,31 +98,31 @@ public class iFacialMocapTrackingInterface : ExtTrackingModule
         UnifiedTracking.Data.Eye._maxDilation = 10;
         #endregion
         #region Eye Brow
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.BrowInnerUpLeft].Weight = server.FaceData.BlendValue("browInnerUp_L");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.BrowLowererLeft].Weight = server.FaceData.BlendValue("browDown_L");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.BrowOuterUpLeft].Weight = server.FaceData.BlendValue("browOuterUp_L");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.BrowPinchLeft].Weight = server.FaceData.BlendValue("browDown_L");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.BrowInnerUpLeft].Weight = server.FaceData.BlendValue("browInnerUp_R");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.BrowLowererLeft].Weight = server.FaceData.BlendValue("browDown_R");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.BrowOuterUpLeft].Weight = server.FaceData.BlendValue("browOuterUp_R");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.BrowPinchLeft].Weight = server.FaceData.BlendValue("browDown_R");
 
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.BrowInnerUpRight].Weight = server.FaceData.BlendValue("browInnerUp_R");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.BrowLowererRight].Weight = server.FaceData.BlendValue("browDown_R");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.BrowOuterUpRight].Weight = server.FaceData.BlendValue("browOuterUp_R");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.BrowPinchRight].Weight = server.FaceData.BlendValue("browDown_R");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.BrowInnerUpRight].Weight = server.FaceData.BlendValue("browInnerUp_L");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.BrowLowererRight].Weight = server.FaceData.BlendValue("browDown_L");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.BrowOuterUpRight].Weight = server.FaceData.BlendValue("browOuterUp_L");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.BrowPinchRight].Weight = server.FaceData.BlendValue("browDown_L");
         #endregion 
         #region Nose
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.NoseSneerLeft].Weight = server.FaceData.BlendValue("noseSneer_L");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.NoseSneerRight].Weight = server.FaceData.BlendValue("noseSneer_R");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.NoseSneerLeft].Weight = server.FaceData.BlendValue("noseSneer_R");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.NoseSneerRight].Weight = server.FaceData.BlendValue("noseSneer_L");
         //Default NasalDitalation & NasalConstrict
         #endregion
         #region Cheek
         UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.CheekPuffLeft].Weight = server.FaceData.BlendValue("cheekPuff");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.CheekSquintLeft].Weight = server.FaceData.BlendValue("cheekSquint_L");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.CheekSquintLeft].Weight = server.FaceData.BlendValue("cheekSquint_R");
         UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.CheekPuffRight].Weight = server.FaceData.BlendValue("cheekPuff");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.CheekSquintRight].Weight = server.FaceData.BlendValue("cheekSquint_R");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.CheekSquintRight].Weight = server.FaceData.BlendValue("cheekSquint_L");
         //No CheekSuck'ing lol
         #endregion
         #region Mewing
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.JawLeft].Weight = server.FaceData.BlendValue("jawLeft");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.JawRight].Weight = server.FaceData.BlendValue("jawRight");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.JawLeft].Weight = server.FaceData.BlendValue("jawRight");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.JawRight].Weight = server.FaceData.BlendValue("jawLeft");
         UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.JawOpen].Weight = server.FaceData.BlendValue("jawOpen");
         UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthClosed].Weight = server.FaceData.BlendValue("mouthClose");
         UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.JawForward].Weight = server.FaceData.BlendValue("jawForward");
@@ -138,7 +141,7 @@ public class iFacialMocapTrackingInterface : ExtTrackingModule
         UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.LipFunnelLowerRight].Weight = server.FaceData.BlendValue("mouthFunnel");
 
         UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.LipSuckUpperLeft].Weight = Math.Min(
-            1f - (float)Math.Pow(server.FaceData.BlendValue("mouthUpperUp_L"), 1 / 6f),
+            1f - (float)Math.Pow(server.FaceData.BlendValue("mouthUpperUp_R"), 1 / 6f),
             server.FaceData.BlendValue("mouthRollUpper")
         );
         UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.LipSuckLowerLeft].Weight = server.FaceData.BlendValue("mouthRollLower");
@@ -153,33 +156,32 @@ public class iFacialMocapTrackingInterface : ExtTrackingModule
         UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthRaiserLower].Weight = server.FaceData.BlendValue("mouthShrugLower");
         UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthRaiserUpper].Weight = server.FaceData.BlendValue("mouthShrugUpper");
 
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthUpperLeft].Weight = server.FaceData.BlendValue("mouthLeft");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthLowerLeft].Weight = server.FaceData.BlendValue("mouthLeft");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthUpperUpLeft].Weight = server.FaceData.BlendValue("mouthUpperUp_L");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthLowerDownLeft].Weight = server.FaceData.BlendValue("mouthLowerDown_L");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthCornerPullLeft].Weight = server.FaceData.BlendValue("mouthSmile_L");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthLowerDownLeft].Weight = server.FaceData.BlendValue("mouthLowerDown_L");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthDimpleLeft].Weight = server.FaceData.BlendValue("mouthDimple_L");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthFrownLeft].Weight = server.FaceData.BlendValue("mouthFrown_L");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthPressLeft].Weight = server.FaceData.BlendValue("mouthPress_L");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthStretchLeft].Weight = server.FaceData.BlendValue("mouthStretch_L");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthUpperLeft].Weight = server.FaceData.BlendValue("mouthRight");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthLowerLeft].Weight = server.FaceData.BlendValue("mouthRight");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthUpperUpLeft].Weight = server.FaceData.BlendValue("mouthUpperUp_R");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthLowerDownLeft].Weight = server.FaceData.BlendValue("mouthLowerDown_R");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthCornerPullLeft].Weight = server.FaceData.BlendValue("mouthSmile_R");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthLowerDownLeft].Weight = server.FaceData.BlendValue("mouthLowerDown_R");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthDimpleLeft].Weight = server.FaceData.BlendValue("mouthDimple_R");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthFrownLeft].Weight = server.FaceData.BlendValue("mouthFrown_R");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthPressLeft].Weight = server.FaceData.BlendValue("mouthPress_R");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthStretchLeft].Weight = server.FaceData.BlendValue("mouthStretch_R");
 
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthUpperRight].Weight = server.FaceData.BlendValue("mouthRight");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthLowerRight].Weight = server.FaceData.BlendValue("mouthRight");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthUpperUpRight].Weight = server.FaceData.BlendValue("mouthUpperUp_R");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthLowerDownRight].Weight = server.FaceData.BlendValue("mouthLowerDown_R");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthCornerPullRight].Weight = server.FaceData.BlendValue("mouthSmile_R");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthLowerDownRight].Weight = server.FaceData.BlendValue("mouthLowerDown_R");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthDimpleRight].Weight = server.FaceData.BlendValue("mouthDimple_R");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthFrownRight].Weight = server.FaceData.BlendValue("mouthFrown_R");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthPressRight].Weight = server.FaceData.BlendValue("mouthPress_R");
-        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthStretchRight].Weight = server.FaceData.BlendValue("mouthStretch_R");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthUpperRight].Weight = server.FaceData.BlendValue("mouthLeft");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthLowerRight].Weight = server.FaceData.BlendValue("mouthLeft");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthUpperUpRight].Weight = server.FaceData.BlendValue("mouthUpperUp_L");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthLowerDownRight].Weight = server.FaceData.BlendValue("mouthLowerDown_L");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthCornerPullRight].Weight = server.FaceData.BlendValue("mouthSmile_L");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthLowerDownRight].Weight = server.FaceData.BlendValue("mouthLowerDown_L");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthDimpleRight].Weight = server.FaceData.BlendValue("mouthDimple_L");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthFrownRight].Weight = server.FaceData.BlendValue("mouthFrown_L");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthPressRight].Weight = server.FaceData.BlendValue("mouthPress_L");
+        UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.MouthStretchRight].Weight = server.FaceData.BlendValue("mouthStretch_L");
 
         //Default MouthUpperDeepenLeft, MouthCornerSlantLeft & MouthTightenerLeft
         #endregion
         #region Tongue
         UnifiedTracking.Data.Shapes[(int)UnifiedExpressions.TongueOut].Weight = server.FaceData.BlendValue("tongueOut");
-        //Not sure if any more
         #endregion
     }
 }

--- a/VRC_iFacialMocap/src/iFacialMocapTrackingInterface.cs
+++ b/VRC_iFacialMocap/src/iFacialMocapTrackingInterface.cs
@@ -60,12 +60,18 @@ public class iFacialMocapTrackingInterface : ExtTrackingModule
     void UpdateData()
     {
         //Could make a dict<UnifiedExpressions,string> or directly assigning Data.Shapes for better performance but can do math here so whatever for now.
-        Console.WriteLine(server.FaceData.BlendValue("jawOpen"));
         #region Eye Gaze
-        UnifiedTracking.Data.Eye.Left.Gaze.x = server.FaceData.BlendValue("eyeLookOut_L") - server.FaceData.BlendValue("eyeLookIn_L");
-        UnifiedTracking.Data.Eye.Left.Gaze.y = server.FaceData.BlendValue("eyeLookUp_L") - server.FaceData.BlendValue("eyeLookDown_L");
-        UnifiedTracking.Data.Eye.Right.Gaze.x = server.FaceData.BlendValue("eyeLookIn_R") - server.FaceData.BlendValue("eyeLookOut_R");
-        UnifiedTracking.Data.Eye.Right.Gaze.y = server.FaceData.BlendValue("eyeLookUp_R") - server.FaceData.BlendValue("eyeLookDown_R");
+        // positive x is to the *right*
+        //UnifiedTracking.Data.Eye.Left.Gaze.x = server.FaceData.BlendValue("eyeLookIn_L") - server.FaceData.BlendValue("eyeLookOut_L");
+        //UnifiedTracking.Data.Eye.Left.Gaze.y = server.FaceData.BlendValue("eyeLookUp_L") - server.FaceData.BlendValue("eyeLookDown_L");
+        //UnifiedTracking.Data.Eye.Right.Gaze.x = server.FaceData.BlendValue("eyeLookOut_R") - server.FaceData.BlendValue("eyeLookIn_R");
+        //UnifiedTracking.Data.Eye.Right.Gaze.y = server.FaceData.BlendValue("eyeLookUp_R") - server.FaceData.BlendValue("eyeLookDown_R");
+
+        // coordinate system is all wacky
+        UnifiedTracking.Data.Eye.Left.Gaze.x = -MathF.Tan(server.FaceData.leftEye[1] / 90.0f); // normalized range of -45 to 45 degrees, tan function
+        UnifiedTracking.Data.Eye.Left.Gaze.y = -MathF.Tan(server.FaceData.leftEye[0] / 90.0f);
+        UnifiedTracking.Data.Eye.Right.Gaze.x = -MathF.Tan(server.FaceData.rightEye[1] / 90.0f);
+        UnifiedTracking.Data.Eye.Right.Gaze.y = -MathF.Tan(server.FaceData.rightEye[0] / 90.0f);
         #endregion
         #region Eye Openness
         UnifiedTracking.Data.Eye.Left.Openness = 1.0f - (float)Math.Max(0, Math.Min(1, server.FaceData.BlendValue("eyeBlink_L") +


### PR DESCRIPTION
iFacialMocap output is inverted by default, which is the nature of ARKit FaceAnchor API 

This PR assigns left -> right for blendshapes

Formerly, the module used expression data for the eyelook (and incorrectly inverted it) instead of the gaze data. 

This PR correctly uses the gaze data from iFacialMocap and sets the orientation as non-mirrored. 

This PR also has the module respect the `eyeAvailable` and `expressionAvailable` initialization arguments, and also respect which part of the face it will update for. 

This PR also improves the connection detail printout in the Output:
![image](https://github.com/user-attachments/assets/c722e626-2d34-4b00-a82b-050e4112316e)

