### PR TITLE
Added manual install instructions and spacing on the images

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,27 @@
 
 A module for VRCFaceTracking v5.1.X.X that hooks iFacialMocap into VRC OSC on desktop mode.
 
-Installation: Download the iFacialMocap module from the VRCFT App
+**Installation:** Download the iFacialMocap module from the VRCFT App.
+
+**Manual Installation:** Import the .Zip on [Releases](https://github.com/Shuisho10/VRC_iFacialMocap/releases/latest) from the VRCFT App, if it gives an error, extract the .zip on `%appdata%\VRCFaceTracking\CustomLibs\f1cc47f2-6bf2-47ef-be36-341e6efa14da`
 
 Setup: Make sure the data is sent to your PC's IP with port `49983`, you can find it out the output logs on the VRCFT App
 If the module times out, restart the VRCFT App and try again
+
 ![ifacialmocap](https://github.com/user-attachments/assets/0cae30d1-5f98-4c08-ada5-4414e883be48)
 
 Where do I put my PC's IP?
 Here's how you do it on iPhone
+
 ![image](https://github.com/user-attachments/assets/b3851685-40c6-449a-aa39-f01f56ab861e)
 
 If you're using the Nvidia app from PC, make sure the output is set to iFacialMocap, you can use any input you'd like
 In this case, leave the IP at 127.0.0.1, you shouldn't have to change any settings
+
 ![image](https://github.com/user-attachments/assets/17339903-bb42-4853-b588-bfe0ef74a1c2)
 
 Note: The module was developed with the Nvidia PC app, we do not have access to iPhones, so even though they're fully supported, we might not be able to easily solve problems when using iPhone, make sure Windows firewalls are set correctly, put your Network profile on Private and double check the settings on your iphone app
+
 ![image](https://github.com/user-attachments/assets/109c0b00-ca24-48c5-a07e-c2bfeccabaaf)
 
 If you're still having issues, we recommend using the [Live link](https://github.com/kusomaigo/VRCFaceTracking-LiveLink) Module instead


### PR DESCRIPTION
Thanks to the Steam release, the module installation folder is now on a set path within the %appdata% folder rather than a random hashed folder on %localappdata%, instructions are given for this